### PR TITLE
修复在Android 5.1及以下版本，由于默认的KeepAliveTime为0, 导致在调用allowCoreThreadTimeOut…

### DIFF
--- a/booster-android-instrument-thread/src/main/java/com/didiglobal/booster/instrument/ShadowScheduledThreadPoolExecutor.java
+++ b/booster-android-instrument-thread/src/main/java/com/didiglobal/booster/instrument/ShadowScheduledThreadPoolExecutor.java
@@ -3,6 +3,7 @@ package com.didiglobal.booster.instrument;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author johnsonlee
@@ -40,6 +41,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(prefix));
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }
@@ -79,6 +83,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(threadFactory, prefix));
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }
@@ -118,6 +125,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(prefix), handler);
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }
@@ -161,6 +171,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(threadFactory, prefix), handler);
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }


### PR DESCRIPTION
…方法时keepAliveTime校验失败从而抛出IllegalArgumentException异常的问题。